### PR TITLE
Uncommented Talons, Discarded Forward and Reverse Limit Switches

### DIFF
--- a/src/main/cpp/commands/SetElevator.cpp
+++ b/src/main/cpp/commands/SetElevator.cpp
@@ -19,8 +19,7 @@ void SetElevator::Execute() {
 
 // Make this return true when this Command no longer needs to run execute()
 bool SetElevator::IsFinished() {
-    return (Elevator::getInstance()->IsFwdLimitSwitchClosed()
-            || Elevator::getInstance()->IsRevLimitSwitchClosed());
+    return Elevator::getInstance()->IsRevLimitSwitchClosed();
 }
 // Called once after isFinished returns true
 void SetElevator::End() {

--- a/src/main/cpp/subsystems/Elevator.cpp
+++ b/src/main/cpp/subsystems/Elevator.cpp
@@ -48,7 +48,6 @@ void Elevator::SetUpTalons(){
 			kPID_PrimaryClosedLoop,
 			kTimeout_10Millis);
 	mRightElevator.ConfigForwardSoftLimitEnable(false, kTimeout_10Millis);
-	//mRightElevator.ConfigForwardLimitSwitchSource(LimitSwitchSource_FeedbackConnector, LimitSwitchNormal_NormallyOpen, kTimeout_10Millis);
 	mRightElevator.ConfigReverseLimitSwitchSource(LimitSwitchSource_FeedbackConnector, LimitSwitchNormal_NormallyOpen, kTimeout_10Millis);
 	mRightElevator.SetSensorPhase(true);
 	mRightElevator.SetInverted(false);

--- a/src/main/cpp/subsystems/Elevator.cpp
+++ b/src/main/cpp/subsystems/Elevator.cpp
@@ -6,6 +6,8 @@
 /*----------------------------------------------------------------------------*/
 #include "RobotMap.h"
 #include "subsystems/Elevator.h"
+using RobotMap::kPID_PrimaryClosedLoop;
+using RobotMap::kTimeout_10Millis;
 
 constexpr char Elevator::kSubsystemName[] = "Elevator";
 
@@ -23,7 +25,7 @@ Elevator::Elevator() : Subsystem("Elevator"),
       mRightElevator(RobotMap::kIDRightElevator)
 
       {
-       // void SetUpTalons();
+    	void SetUpTalons();
       }
 
 
@@ -41,26 +43,21 @@ void Elevator::SetElevator(double speed) {
   RightElevator.Set(ControlMode::MotionMagic, position);
 }*/
 
-/*void Elevator::SetUpTalons(){
-  RightElevator.ConfigSelectedFeedbackSensor(FeedbackDevice::CTRE_MagEncoder_Relative,
+void Elevator::SetUpTalons(){
+  mRightElevator.ConfigSelectedFeedbackSensor(FeedbackDevice::CTRE_MagEncoder_Relative,
 			kPID_PrimaryClosedLoop,
 			kTimeout_10Millis);
-	RightElevator.ConfigForwardSoftLimitEnable(false, kTimeout_10Millis);
-	RightElevator.ConfigReverseSoftLimitEnable(false, kTimeout_10Millis);
-	RightElevator.ConfigForwardLimitSwitchSource(LimitSwitchSource_FeedbackConnector, LimitSwitchNormal_NormallyOpen, kTimeout_10Millis);
-	RightElevator.ConfigReverseLimitSwitchSource(LimitSwitchSource_FeedbackConnector, LimitSwitchNormal_NormallyOpen, kTimeout_10Millis);
-	RightElevator.SetSensorPhase(true);
-	RightElevator.SetInverted(false);
-	RightElevator.ConfigPeakOutputForward(0.1, kTimeout_10Millis);
-	RightElevator.ConfigPeakOutputReverse(-0.02, kTimeout_10Millis);
+	mRightElevator.ConfigForwardSoftLimitEnable(false, kTimeout_10Millis);
+	//mRightElevator.ConfigForwardLimitSwitchSource(LimitSwitchSource_FeedbackConnector, LimitSwitchNormal_NormallyOpen, kTimeout_10Millis);
+	mRightElevator.ConfigReverseLimitSwitchSource(LimitSwitchSource_FeedbackConnector, LimitSwitchNormal_NormallyOpen, kTimeout_10Millis);
+	mRightElevator.SetSensorPhase(true);
+	mRightElevator.SetInverted(false);
+	mRightElevator.ConfigPeakOutputForward(0.1, kTimeout_10Millis);
+	mRightElevator.ConfigPeakOutputReverse(-0.02, kTimeout_10Millis);
 
-	LeftElevator.SetInverted(true);
-	LeftElevator.Follow(RightElevator);
+	mLeftElevator.SetInverted(true);
+	mLeftElevator.Follow(mRightElevator);
 
-}*/
-
-bool Elevator::IsFwdLimitSwitchClosed() {
-	return mRightElevator.GetSensorCollection().IsFwdLimitSwitchClosed();
 }
 
 bool Elevator::IsRevLimitSwitchClosed() {

--- a/src/main/include/subsystems/Elevator.h
+++ b/src/main/include/subsystems/Elevator.h
@@ -16,7 +16,7 @@ class Elevator : public frc::Subsystem {
         WPI_TalonSRX mLeftElevator;
         WPI_TalonSRX mRightElevator;
 
-        //void SetUpTalons();
+        void SetUpTalons();
   
  public:
         static std::shared_ptr<Elevator> getInstance();


### PR DESCRIPTION
Uncommented out the SetUpTalons function and changed all the names of the motors to fit the new naming style. In addition, we got rid of the frwd Limit Switch and the rev soft limit switch. In conclusion, we fixed the SetElevator command to not include those limit switches.