### PR TITLE
reset position on robot enable

### DIFF
--- a/src/main/cpp/Robot.cpp
+++ b/src/main/cpp/Robot.cpp
@@ -9,11 +9,12 @@
 
 #include <frc/commands/Scheduler.h>
 #include <frc/smartdashboard/SmartDashboard.h>
+
 #include "subsystems/CargoCarriage.h"
-#include "subsystems/Chassis.h"
-#include "subsystems/HatchIntake.h"
-#include "subsystems/Elevator.h"
 #include "subsystems/CargoIntake.h"
+#include "subsystems/Chassis.h"
+#include "subsystems/Elevator.h"
+#include "subsystems/HatchIntake.h"
 
 ExampleSubsystem Robot::m_subsystem;
 OI Robot::m_oi;

--- a/src/main/cpp/Robot.cpp
+++ b/src/main/cpp/Robot.cpp
@@ -85,6 +85,9 @@ void Robot::AutonomousInit() {
   //   m_autonomousCommand = &m_defaultAuto;
   // }
 
+  Elevator::getInstance()->ResetPosition();
+  HatchIntake::getInstance()->ResetPosition();
+
   m_autonomousCommand = m_chooser.GetSelected();
 
   if (m_autonomousCommand != nullptr) {
@@ -103,6 +106,9 @@ void Robot::TeleopInit() {
     m_autonomousCommand->Cancel();
     m_autonomousCommand = nullptr;
   }
+
+  Elevator::getInstance()->ResetPosition();
+  HatchIntake::getInstance()->ResetPosition();
 }
 
 void Robot::TeleopPeriodic() { frc::Scheduler::GetInstance()->Run(); }

--- a/src/main/cpp/subsystems/Elevator.cpp
+++ b/src/main/cpp/subsystems/Elevator.cpp
@@ -188,3 +188,8 @@ double Elevator::InchesToEncoderTicks(double inches) {
   double encoder = inchesToEncoder(inches);
   return encoder;
 }
+
+void Elevator::ResetPosition() {
+  double position = GetEncoderValue();
+  SetElevatorPosition(position); 
+}

--- a/src/main/cpp/subsystems/HatchIntake.cpp
+++ b/src/main/cpp/subsystems/HatchIntake.cpp
@@ -118,6 +118,7 @@ int HatchIntake::GetPosition()
 {
   return mPivot.GetSelectedSensorPosition(kPID_PrimaryClosedLoop);
 }
+
 void HatchIntake::SetupMotionMagic()
 {
   mPivot.SetStatusFramePeriod(StatusFrameEnhanced::Status_13_Base_PIDF0, 10, kTimeout_10Millis);
@@ -222,5 +223,9 @@ bool HatchIntake::IsEngage() {
   return mPuncher.Get() == kMotorEngage;
 }
 
+void HatchIntake::ResetPosition() {
+  double encoder = GetPosition();
+  PivotPosition(encoder);
+}
 // Put methods for controlling this subsystem
 // here. Call these from Commands.

--- a/src/main/include/subsystems/Elevator.h
+++ b/src/main/include/subsystems/Elevator.h
@@ -48,5 +48,5 @@ class Elevator : public frc::Subsystem {
         double InchesToEncoderTicks(double inches);
         void SetElevatorPositionInches(double inches);
 
-
+       void ResetPosition();
 };

--- a/src/main/include/subsystems/HatchIntake.h
+++ b/src/main/include/subsystems/HatchIntake.h
@@ -59,5 +59,5 @@ class HatchIntake : public frc::Subsystem {
   double GetArmPotVoltage();
   bool IsEngage();
   
-
+  void ResetPosition();
 };


### PR DESCRIPTION
When the robot is enabled into autonomous or teleop, reset the positions of the elevator and the hatch intake so that they don't move.