### PR TITLE
Use Differential Drive

### DIFF
--- a/src/main/cpp/subsystems/Chassis.cpp
+++ b/src/main/cpp/subsystems/Chassis.cpp
@@ -51,14 +51,9 @@ void Chassis::SetTankDrive(double left, double right) {
   constexpr auto kHighGear = 0.75;
   constexpr auto kLowGear = 0.25;
 
-  if (IsHighGear())
-  {
-    left *= kHighGear;
-    right *= kHighGear;
-  } else {
-    left *= kLowGear;
-    right *= kLowGear;
- }
+  auto gear = IsHighGear() ? kHighGear : kLowGear;
+  left *= gear;
+  right *= gear;
 
   m_drive.TankDrive(left, right);
 }

--- a/src/main/cpp/subsystems/Chassis.cpp
+++ b/src/main/cpp/subsystems/Chassis.cpp
@@ -23,6 +23,9 @@ Chassis::Chassis() : Subsystem(kSubsystemName),
   left2Wheel{RobotMap::kIDLeft2Wheel, rev::CANSparkMax::MotorType::kBrushless},
   leftEncoder{left1Wheel.GetEncoder()},
   rightEncoder{right1Wheel.GetEncoder()},
+  m_left{left1Wheel, left2Wheel},
+  m_right{right1Wheel, right2Wheel},
+  m_drive{m_left, m_right},
   mIsHighGear(true)
   {
     left1Wheel.SetOpenLoopRampRate(0.2);
@@ -60,6 +63,10 @@ void Chassis::SetTankDrive(double left, double right) {
   left2Wheel.Set(left);
   right2Wheel.Set(right);
 
+}
+
+void Chassis::SetArcadeDrive(double speed, double rotation) {
+  m_drive.ArcadeDrive(speed, rotation);
 }
 
 void Chassis::DriveChassis(double speed) {

--- a/src/main/cpp/subsystems/Chassis.cpp
+++ b/src/main/cpp/subsystems/Chassis.cpp
@@ -38,6 +38,8 @@ Chassis::Chassis() : Subsystem(kSubsystemName),
 
     //right2Wheel.Follow(right1Wheel);
     //left2Wheel.Follow(left1Wheel); 
+
+    m_drive.SetRightSideInverted(false);
   }
 
 void Chassis::InitDefaultCommand() {
@@ -58,11 +60,7 @@ void Chassis::SetTankDrive(double left, double right) {
     right *= kLowGear;
  }
 
-  left1Wheel.Set(left);
-  right1Wheel.Set(right);
-  left2Wheel.Set(left);
-  right2Wheel.Set(right);
-
+  m_drive.TankDrive(left, right);
 }
 
 void Chassis::SetArcadeDrive(double speed, double rotation) {
@@ -70,10 +68,7 @@ void Chassis::SetArcadeDrive(double speed, double rotation) {
 }
 
 void Chassis::DriveChassis(double speed) {
-  left1Wheel.Set(speed*.75);
-  left2Wheel.Set(speed*.75);
-  right1Wheel.Set(speed*.75);
-  right2Wheel.Set(speed*.75);
+  m_drive.TankDrive(speed, speed);
 }
 
 double Chassis::GetLeftPosition() {

--- a/src/main/include/subsystems/Chassis.h
+++ b/src/main/include/subsystems/Chassis.h
@@ -3,6 +3,8 @@
 #include <frc/commands/Subsystem.h>
 #include "rev/CANSparkMax.h"
 #include "rev/CANEncoder.h"
+#include <frc/Drive/DifferentialDrive.h>
+#include <frc/SpeedControllerGroup.h>
 
 class Chassis: public frc::Subsystem {
 private:
@@ -16,6 +18,12 @@ private:
   rev::CANSparkMax left2Wheel;
   rev::CANEncoder leftEncoder;
   rev::CANEncoder rightEncoder;
+
+  
+	frc::SpeedControllerGroup m_left;
+	frc::SpeedControllerGroup m_right;
+  frc::DifferentialDrive m_drive;
+
 
   bool mIsHighGear;
 
@@ -40,6 +48,7 @@ private:
   double GetRightCurrent();
   double GetLeftVoltage();
   double GetRightVoltage();
+  void SetArcadeDrive(double speed, double rotation);
   
   void SetHighGear() { mIsHighGear = true; }
   void SetLowGear() { mIsHighGear = false; }

--- a/src/main/include/subsystems/Chassis.h
+++ b/src/main/include/subsystems/Chassis.h
@@ -20,8 +20,8 @@ private:
   rev::CANEncoder rightEncoder;
 
   
-	frc::SpeedControllerGroup m_left;
-	frc::SpeedControllerGroup m_right;
+  frc::SpeedControllerGroup m_left;
+  frc::SpeedControllerGroup m_right;
   frc::DifferentialDrive m_drive;
 
 


### PR DESCRIPTION
I high jacked Nic's branch.

We should practice tomorrow with the changes for TankDrive. 

This uses the DifferentialDrive::TankDrive capability which has some nice functionality we've never had:

* squared inputs. This gives you more control at slow speeds and fast response at high speeds. Try adjustments at slow speeds to see how you like it. The gear shift is still in, see if you like it or not.
* dead band. Any values smaller than .02 are zero. The rest of the range is scaled to fill the entire range. The dead band will help to prevent the robot drifting when you let go of the joystick.

Try these changes. We can always reverse or adjust them.